### PR TITLE
Dependency and target framework tweaks

### DIFF
--- a/src/Minid/Minid.csproj
+++ b/src/Minid/Minid.csproj
@@ -7,13 +7,12 @@
         <PackageId>Minid</PackageId>
         <Description>Minid generates human-readable, URL-friendly, unique identifiers that are computed in-memory</Description>
     </PropertyGroup>
+    
     <ItemGroup>
-        <PackageReference Include="MinVer" Version="4.2.0"/>
+        <PackageReference Include="MinVer" Version="4.2.0" PrivateAssets="All"/>
     </ItemGroup>
+    
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
-        <PackageReference Include="System.Text.Json" Version="[5.0.2,6.0)" />
-    </ItemGroup>
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
         <PackageReference Include="System.Text.Json" Version="[5.0.2,6.0)" />
     </ItemGroup>
 </Project>

--- a/src/Minid/Minid.csproj
+++ b/src/Minid/Minid.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net5.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net5.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <RootNamespace>Minid</RootNamespace>
         <AssemblyName>Minid</AssemblyName>


### PR DESCRIPTION
Is there a reason you had a separate target for `net6.0`? It doesn't seem like the library is using any .NET 6-specific APIs.