### PR TITLE
Remove sources property from sonarinit

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -79,7 +79,6 @@ Task("SonarBegin")
             Exclusions = "test/**,examples/**,benchmarks/**",
             OpenCoverReportsPath = $"{coveragePath}/*.xml",
             Login = sonarToken,
-            Sources
             VsTestReportsPath = $"{artifactsPath}/*.TestResults.xml",
         });
     });


### PR DESCRIPTION
Not sure how the `Sources` property crept in there but it was causing the build script to fail