### PR TITLE
Parse

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -6,7 +6,6 @@
 // Install addins 
 #addin nuget:?package=Cake.Sonar&version=1.1.30
 
-
  #r "System.Text.Json"
  #r "System.IO"
 
@@ -224,10 +223,10 @@ Task("Default")
     .IsDependentOn("GenerateReports");
 
 Task("CI")
-    .IsDependentOn("SonarBegin")
+    //.IsDependentOn("SonarBegin")
     .IsDependentOn("Default")
     .IsDependentOn("UploadCoverage")
-    .IsDependentOn("SonarEnd");
+    //.IsDependentOn("SonarEnd");
 
 Task("Publish")
     .IsDependentOn("CI")

--- a/build.cake
+++ b/build.cake
@@ -225,7 +225,7 @@ Task("Default")
 Task("CI")
     //.IsDependentOn("SonarBegin")
     .IsDependentOn("Default")
-    .IsDependentOn("UploadCoverage")
+    .IsDependentOn("UploadCoverage");
     //.IsDependentOn("SonarEnd");
 
 Task("Publish")

--- a/build.cake
+++ b/build.cake
@@ -4,9 +4,7 @@
 #tool "dotnet:?package=dotnet-sonarscanner&version=5.8.0"
 
 // Install addins 
-#addin nuget:?package=Cake.Coverlet&version=2.5.4
 #addin nuget:?package=Cake.Sonar&version=1.1.30
-// #addin nuget:?package=Cake.Git&version=2.0.0
 
 
  #r "System.Text.Json"
@@ -98,28 +96,26 @@ Task("Test")
         foreach (var project in GetFiles(testFiles))
         {
             var projectName = project.GetFilenameWithoutExtension();
+            var coverageOutputName = $"{projectName}.opencover.xml";
+            var outputPath = FilePath.FromString(System.IO.Path.Combine(coveragePath, coverageOutputName))
+                .MakeAbsolute(Context.Environment);
+
+            Information(outputPath);
             
-            var testSettings = new DotNetCoreTestSettings 
+            var testSettings = new DotNetTestSettings 
             {
                 NoBuild = true,
                 Configuration = configuration,
                 Loggers = { $"trx;LogFileName={projectName}.TestResults.xml" },
-                ResultsDirectory = artifactsPath
+                ResultsDirectory = artifactsPath,
+                ArgumentCustomization = args => 
+                    args.Append("/p:CollectCoverage=true")
+                        .Append("/p:CoverletOutputFormat=opencover")
+                        .Append($"/p:CoverletOutput={outputPath}")
+                        .Append($"/p:Threshold={coverageThreshold}")
             };
             
-            // https://github.com/Romanx/Cake.Coverlet
-            var coverletSettings = new CoverletSettings 
-            {
-                CollectCoverage = true,
-                CoverletOutputFormat = CoverletOutputFormat.opencover,
-                CoverletOutputDirectory = coveragePath,
-                CoverletOutputName = $"{projectName}.opencover.xml",
-                Threshold = coverageThreshold
-            };
-            
-            // This method is exposed by Cake.Coverlet which has not yet been
-            // updated to target Cake.Core 2.0
-            DotNetCoreTest(project.ToString(), testSettings, coverletSettings);
+            DotNetTest(project.ToString(), testSettings);
         }
    });
 

--- a/src/Minid/Id.cs
+++ b/src/Minid/Id.cs
@@ -130,7 +130,7 @@ public struct Id : IEquatable<Id>
 
     private static bool TryGetPrefix(ReadOnlySpan<char> value, out int index, out ReadOnlySpan<char> prefix)
     {
-        index = value.IndexOf(Separator);
+        index = value.LastIndexOf(Separator);
         prefix = default;
 
         if (index > 0)

--- a/src/Minid/Id.cs
+++ b/src/Minid/Id.cs
@@ -41,6 +41,15 @@ public struct Id : IEquatable<Id>
     public static Id NewId(string? prefix = null) => new(Guid.NewGuid(), prefix);
     public static Id Empty => new(Guid.Empty);
 
+    public static Id Parse(ReadOnlySpan<char> value, string prefix)
+    {
+        if (!TryParse(value, prefix, out Id result))
+        {
+            throw new ArgumentException("Value cannot be parsed", nameof(value));
+        }
+
+        return result;
+    }
 
     public static bool TryParse(ReadOnlySpan<char> value, string prefix, out Id result)
     {
@@ -67,6 +76,16 @@ public struct Id : IEquatable<Id>
 
         result = default;
         return false;
+    }
+
+    public static Id Parse(ReadOnlySpan<char> value)
+    {
+        if (!TryParse(value, out Id result))
+        {
+            throw new ArgumentException("Value cannot be parsed", nameof(value));
+        }
+
+        return result;
     }
 
     public static bool TryParse(ReadOnlySpan<char> value, out Id result)

--- a/src/Minid/Id.cs
+++ b/src/Minid/Id.cs
@@ -30,13 +30,14 @@ public struct Id : IEquatable<Id>
     private static readonly string EmptyString = new('0', Length);
 
     private readonly Guid _value;
-    private readonly string? _prefix;
 
     public Id(Guid value, string? prefix = default)
     {
         _value = value;
-        _prefix = prefix;
+        Prefix = prefix;
     }
+
+    public string? Prefix { get; }
 
     public static Id NewId(string? prefix = null) => new(Guid.NewGuid(), prefix);
     public static Id Empty => new(Guid.Empty);
@@ -144,7 +145,7 @@ public struct Id : IEquatable<Id>
     /// Converts the ID to a base-32 encoded value
     /// </summary>
     /// <returns></returns>
-    public override string ToString() => Encode(_value, _prefix);
+    public override string ToString() => Encode(_value, Prefix);
 
     /// <summary>
     /// Encodes the provided Guid value

--- a/test/Minid.Tests/IdTests.cs
+++ b/test/Minid.Tests/IdTests.cs
@@ -7,6 +7,7 @@ public class IdTests
     public void Can_encode_and_decode()
     {
         var id = Id.NewId();
+
         string encoded = id.ToString();
 
         Id.TryParse(encoded, out Id decoded).ShouldBeTrue();

--- a/test/Minid.Tests/IdTests.cs
+++ b/test/Minid.Tests/IdTests.cs
@@ -55,26 +55,30 @@ public class IdTests
         encoded.Length.ShouldBe(31); // prefix + separator + 26 encoded guid
     }
 
-    [Fact]
-    public void Can_decode_prefixed_id()
+    [Theory]
+    [InlineData("cust")]
+    [InlineData("a_cust")]
+    public void Can_decode_prefixed_id(string prefix)
     {
-        var id = Id.NewId(prefix: "cust");
+        var id = Id.NewId(prefix: prefix);
         var encoded = id.ToString();
 
         Id.TryParse(encoded, out Id decoded).ShouldBeTrue();
         decoded.ShouldBe(id);
-        decoded.ToString().ShouldStartWith("cust_");
+        decoded.ToString().ShouldStartWith(prefix + "_");
     }
 
-    [Fact]
-    public void Can_decode_known_prefixed_id()
+    [Theory]
+    [InlineData("cust")]
+    [InlineData("a_cust")]
+    public void Can_decode_known_prefixed_id(string prefix)
     {
-        var id = Id.NewId(prefix: "cust");
+        var id = Id.NewId(prefix: prefix);
         var encoded = id.ToString();
 
-        Id.TryParse(encoded, "cust", out Id decoded).ShouldBeTrue();
+        Id.TryParse(encoded, prefix, out Id decoded).ShouldBeTrue();
         decoded.ShouldBe(id);
-        decoded.ToString().ShouldStartWith("cust_");
+        decoded.ToString().ShouldStartWith(prefix + "_");
     }
 
     [Theory]

--- a/test/Minid.Tests/IdTests.cs
+++ b/test/Minid.Tests/IdTests.cs
@@ -94,4 +94,30 @@ public class IdTests
     {
         Id.TryParse(encoded, knownPrefix, out Id _).ShouldBe(isValid);
     }
+
+    [Theory]
+    [InlineData("473cr1y0ghbyc3m1yfbwvn3nxx")]
+    [InlineData("acc_473cr1y0ghbyc3m1yfbwvn3nxx")]
+    public void Can_parse(string encoded)
+    {
+        Id.Parse(encoded);
+    }
+
+    [Fact]
+    public void Can_parse_throws_if_invalid()
+    {
+        Should.Throw<ArgumentException>(() => Id.Parse("invalid"));
+    }
+
+    [Fact]
+    public void Can_parse_with_prefix()
+    {
+        Id.Parse("acc_473cr1y0ghbyc3m1yfbwvn3nxx", "acc");
+    }
+
+    [Fact]
+    public void Can_parse_with_prefix_throws_if_invalid()
+    {
+        Should.Throw<ArgumentException>(() => Id.Parse("invalid", "acc"));
+    }
 }


### PR DESCRIPTION
This PR adds a `Parse` method to satisfy cases where a known valid encoded value needs to be parsed. 

Also fixes:

- Prefix is not exposed
- Fixes #8 