### PR TITLE
Improve the performance of get prefix

### DIFF
--- a/benchmarks/Minid.Benchmarks/Benchmarks.cs
+++ b/benchmarks/Minid.Benchmarks/Benchmarks.cs
@@ -50,3 +50,21 @@ public class PrefixedIdBenchmarks
         return decoded;
     }
 }
+
+[MemoryDiagnoser]
+public class IndexOfBenchmarks
+{
+    [Benchmark]
+    public int IndexOf()
+    {
+        ReadOnlySpan<char> id = "cust_473cr1y0ghbyc3m1yfbwvn3nxx";
+        return id.IndexOf("_");
+    }
+
+    [Benchmark]
+    public int LastIndexOf()
+    {
+        ReadOnlySpan<char> id = "cust_473cr1y0ghbyc3m1yfbwvn3nxx";
+        return id[..26].LastIndexOf('_');
+    }
+}

--- a/src/Minid/Id.cs
+++ b/src/Minid/Id.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -130,12 +131,23 @@ public struct Id : IEquatable<Id>
 
     private static bool TryGetPrefix(ReadOnlySpan<char> value, out int index, out ReadOnlySpan<char> prefix)
     {
-        index = value.LastIndexOf(Separator);
         prefix = default;
+
+        // If the length is less or equal to the encoded length
+        // then it can't have a prefix and/or be valid
+        if (value.Length <= Length)
+        {
+            index = -1;
+            return false;
+        }
+
+        // Prefix can only be in the start of the string minus encoded length
+        prefix = value[..^26];
+        index = prefix.LastIndexOf(Separator);
 
         if (index > 0)
         {
-            prefix = value.Slice(0, index);
+            prefix = prefix[..index];
         }
 
         return index > 0; // Must have at least a character before the separator

--- a/test/Minid.Tests/IdTests.cs
+++ b/test/Minid.Tests/IdTests.cs
@@ -65,6 +65,7 @@ public class IdTests
 
         Id.TryParse(encoded, out Id decoded).ShouldBeTrue();
         decoded.ShouldBe(id);
+        decoded.Prefix.ShouldBe(prefix);
         decoded.ToString().ShouldStartWith(prefix + "_");
     }
 
@@ -78,6 +79,7 @@ public class IdTests
 
         Id.TryParse(encoded, prefix, out Id decoded).ShouldBeTrue();
         decoded.ShouldBe(id);
+        decoded.Prefix.ShouldBe(prefix);
         decoded.ToString().ShouldStartWith(prefix + "_");
     }
 


### PR DESCRIPTION
This PR improves the performance of getting the prefix from a string by reducing the input span to only possible prefix characters (overall length - encoded length (26)).

This should now be faster than the original implementation that used `IndexOf` since we're working backwards so have less characters to read.